### PR TITLE
[wip] accepts an extra query param to fetch extra attributes for a user

### DIFF
--- a/api.js
+++ b/api.js
@@ -58,7 +58,7 @@ server.get('/api/v1/changesets/:id', function(req, res, next) {
 });
 
 server.get('/api/v1/users/name/:name', function(req, res, next) {
-    users.getName(req.params.name, function(err, json) {
+    users.getName(req.params.name, req.query, function(err, json) {
         if (err) {
             return next(err);
         }
@@ -67,7 +67,7 @@ server.get('/api/v1/users/name/:name', function(req, res, next) {
 });
 
 server.get('/api/v1/users/id/:id', function(req, res, next) {
-    users.getId(req.params.id, function(err, json) {
+    users.getId(req.params.id, req.query, function(err, json) {
         if (err) {
             return next(err);
         }

--- a/users/index.js
+++ b/users/index.js
@@ -74,8 +74,10 @@ function fetchExtra(user, client, done, callback) {
     var q = queue(3);
     var totalDiscussionsQ = 'SELECT COUNT(id) FROM changeset_comments WHERE user_id=$1';
     var discussedChangesetsQ = 'SELECT COUNT(id) FROM changesets WHERE (SELECT COUNT(id) FROM changeset_comments WHERE changeset_comments.changeset_id = changesets.id) > 0 AND changesets.discussion_count > 0 AND changesets.user_id = $1';
+    var mappingDaysQ = "SELECT COUNT(DISTINCT(date_trunc('day', created_at))) FROM changesets WHERE user_id=$1";
     q.defer(client.query.bind(client), totalDiscussionsQ, [userId]);
     q.defer(client.query.bind(client), discussedChangesetsQ, [userId]);
+    q.defer(client.query.bind(client), mappingDaysQ, [userId]);
     q.awaitAll(function(err, results) {
         done();
         if (err) {
@@ -83,7 +85,8 @@ function fetchExtra(user, client, done, callback) {
         }
         user.extra = {
             'total_discussions': results[0].rows[0].count,
-            'changesets_with_discussions': results[1].rows[0].count
+            'changesets_with_discussions': results[1].rows[0].count,
+            'mapping_days': results[2].rows[0].count
         };
         return callback(null, user);
     });

--- a/users/index.js
+++ b/users/index.js
@@ -2,15 +2,16 @@ var config = require('../lib/config')();
 var queue = require('d3-queue').queue;
 var pg = require('pg');
 var errors = require('../errors');
-
 var users = {};
 
 module.exports = users;
 
 var pgURL = config.PostgresURL;
 
-users.getName = function(name, callback) {
-    query(name, 'name', function (err, user) {
+users.getName = function(name, queryParams, callback) {
+    var extra = false;
+    if (queryParams.extra) extra = true;
+    query(name, 'name', extra, function (err, user) {
         if (err) {
             return callback(err, null);
         }
@@ -19,8 +20,10 @@ users.getName = function(name, callback) {
     });
 };
 
-users.getId = function(id, callback) {
-    query(id, 'id', function (err, user) {
+users.getId = function(id, query, callback) {
+    var extra = false;
+    if (query.extra) extra = true;
+    query(id, 'id', extra, function (err, user) {
         if (err) {
             return callback(err, null);
         }
@@ -29,7 +32,14 @@ users.getId = function(id, callback) {
     });
 };
 
-function query(value, thing, callback) {
+
+/*
+    @param {String} value - should be either the user id or username being searched for
+    @param {String} thing - either `id` or `name`, corresponding to type of value provided
+    @param {Boolean} extra - whether to fetch extra attributes for the user
+    @param {Function} callback - callback to call with fetched data
+*/
+function query(value, thing, extra, callback) {
     var userQuery = 'SELECT * FROM users WHERE ' + thing + '= $1';
     pg.connect(pgURL, function(err, client, done) {
         if (err) {
@@ -37,14 +47,44 @@ function query(value, thing, callback) {
             return;
         }
         client.query(userQuery, [value], function(err, result) {
-            done();
             if (err) {
                 return callback(err, null);
             }
             if (result.rows.length === 0) {
                 return callback(new errors.NotFoundError('User not found'));
             }
-            callback(null, result.rows[0]);
+            var user = result.rows[0];
+            if (extra) {
+                return fetchExtra(user, client, done, callback);
+            } else {
+                return callback(null, user);
+            }
         });
+    });
+}
+
+/*
+    @param {Object} user - basic user details
+    @param {PGClient Object} client - a postgres client connection instance
+    @param {Function} done - function to call to close connection to db
+    @param {Function} callback - function to call with basic data augmented with extra attributes
+*/
+function fetchExtra(user, client, done, callback) {
+    var userId = user.id;
+    var q = queue(3);
+    var totalDiscussionsQ = 'SELECT COUNT(id) FROM changeset_comments WHERE user_id=$1';
+    var discussedChangesetsQ = 'SELECT COUNT(id) FROM changesets WHERE (SELECT COUNT(id) FROM changeset_comments WHERE changeset_comments.changeset_id = changesets.id) > 0 AND changesets.discussion_count > 0 AND changesets.user_id = $1';
+    q.defer(client.query.bind(client), totalDiscussionsQ, [userId]);
+    q.defer(client.query.bind(client), discussedChangesetsQ, [userId]);
+    q.awaitAll(function(err, results) {
+        done();
+        if (err) {
+            return callback(err);
+        }
+        user.extra = {
+            'total_discussions': results[0].rows[0].count,
+            'changesets_with_discussions': results[1].rows[0].count
+        };
+        return callback(null, user);
     });
 }


### PR DESCRIPTION
Refs #59

Currently implements:
 - Fetch discussion count for user
 - Fetch count of changesets of user that have discussions

TODO:
 - Fetch unique mapping days of user.

@geohacker ^ I may need your help to formulate that query. We want the count of all unique `days` for the user's changeset timestamps.